### PR TITLE
Adds option to add a postfix to the state

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -1189,13 +1189,13 @@ func checkAllowedEmails(req *http.Request, s *sessionsapi.SessionState) bool {
 // encodedState builds the OAuth state param out of our nonce and
 // original application redirect
 func encodeState(nonce string, redirect string, additional string) string {
-	return fmt.Sprintf("%v:%v:%v", nonce, redirect, additional)
+	return fmt.Sprintf("%v|%v|%v", nonce, redirect, additional)
 }
 
 // decodeState splits the reflected OAuth state response back into
 // the nonce and original application redirect
 func decodeState(req *http.Request) (string, string, string, error) {
-	state := strings.SplitN(req.Form.Get("state"), ":", 3)
+	state := strings.SplitN(req.Form.Get("state"), "|", 3)
 
 	if len(state) != 3 {
 		return "", "", "", errors.New("invalid length")

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -413,7 +413,7 @@ func (patTest *PassAccessTokenTest) getCallbackEndpoint() (httpCode int, cookie 
 		http.MethodGet,
 		fmt.Sprintf(
 			"/oauth2/callback?code=callback_code&state=%s",
-			encodeState(csrf.HashOAuthState(), "%2F"),
+			encodeState(csrf.HashOAuthState(), "", "%2F"),
 		),
 		strings.NewReader(""),
 	)

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -27,6 +27,7 @@ type Options struct {
 	TrustedIPs         []string `flag:"trusted-ip" cfg:"trusted_ips"`
 	ForceHTTPS         bool     `flag:"force-https" cfg:"force_https"`
 	RawRedirectURL     string   `flag:"redirect-url" cfg:"redirect_url"`
+	StatePostfix       string   `flag:"state-postfix" cfg:"state_postfix"`
 
 	AuthenticatedEmailsFile string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	EmailDomains            []string `flag:"email-domain" cfg:"email_domains"`
@@ -151,6 +152,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Int("redis-connection-idle-timeout", 0, "Redis connection idle timeout seconds, if Redis timeout option is non-zero, the --redis-connection-idle-timeout must be less then Redis timeout option")
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 	flagSet.Bool("gcp-healthchecks", false, "Enable GCP/GKE healthcheck endpoints")
+	flagSet.String("state-postfix", "", "state_postifx")
 
 	flagSet.AddFlagSet(cookieFlagSet())
 	flagSet.AddFlagSet(loggingFlagSet())


### PR DESCRIPTION
Adds option to add a postfix to the state for routing and potentially other purposes.
Can be enabled via --state-postfix command line parameter or setting the OAUTH2_PROXY_STATE_POSTFIX environment variable.
Returned state value by the idp will be of the format `nonce:app-redirect:postfix`